### PR TITLE
Display better errors when validating action/workflow configurations

### DIFF
--- a/inngest/internal/cuedefs/cuedefs.go
+++ b/inngest/internal/cuedefs/cuedefs.go
@@ -115,7 +115,9 @@ func parseDef(input, lookup, suffix string) (*cue.Value, error) {
 	runtime := cuecontext.New()
 	inst := runtime.BuildInstance(instances[0])
 	if err := inst.Err(); err != nil {
-		return nil, fmt.Errorf("config is invalid: %w", err)
+		buf := &bytes.Buffer{}
+		cueerrors.Print(buf, err, nil)
+		return nil, fmt.Errorf("config is invalid: %s", buf.String())
 	}
 
 	// Find the variable defined as "workflow":  this is a constant used to reference
@@ -128,7 +130,7 @@ func parseDef(input, lookup, suffix string) (*cue.Value, error) {
 	}
 
 	if err := wval.Validate(cue.Final(), cue.Concrete(true)); err != nil {
-		return nil, fmt.Errorf("config is invalud: %w:", err)
+		return nil, fmt.Errorf("config is invalid: %w:", err)
 	}
 
 	return &wval, nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -171,8 +171,6 @@ github.com/moby/term/windows
 github.com/morikuni/aec
 # github.com/mpvl/unique v0.0.0-20150818121801-cbe035fff7de
 github.com/mpvl/unique
-# github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5
-## explicit
 # github.com/opencontainers/go-digest v1.0.0
 github.com/opencontainers/go-digest
 # github.com/opencontainers/image-spec v1.0.1


### PR DESCRIPTION
Before:

```
Invalid configuration: error parsing action definition: config is invalid: action.workflowMetadata.contents.form: 1 errors in empty disjunction: (and 1 more errors)
```

After:

```
Invalid configuration: error parsing action definition: config is invalid: expected newline after multiline quote """:
    -:44:12
```

```
Invalid configuration: error parsing action definition: config is invalid: action.workflowMetadata.ios_attachments.form: incomplete value {title:"iOS media attachments",hint:"JSON object containing keys of IDs to URLs",type:"input",templating:*true | bool} | {title:"iOS media attachments",hint:"JSON object containing keys of IDs to URLs",type:"select",other:*false | bool,choices:*[] | []} | {title:"iOS media attachments",hint:"JSON object containing keys of IDs to URLs",type:"textarea",templating:*true | bool} | {title:"iOS media attachments",hint:"JSON object containing keys of IDs to URLs",type:"datetime",templating:*true | bool} | {title:"iOS media attachments",hint:"JSON object containing keys of IDs to URLs",type:"toggle",templating:*true | bool}:
```