### PR TITLE
Action UX improvements

### DIFF
--- a/cmd/commands/actions.go
+++ b/cmd/commands/actions.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"os"
 	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/inngest/inngestctl/cmd/commands/internal/actions"
@@ -20,11 +19,10 @@ import (
 )
 
 var (
-	pushOnly             bool
-	includePublic        bool
-	deployWithoutPublish bool
-	versionRegex         = regexp.MustCompile(`^v?([0-9]+).([0-9]+)$`)
-	spacesRegex          = regexp.MustCompile(`\s`)
+	pushOnly      bool
+	includePublic bool
+	versionRegex  = regexp.MustCompile(`^v?([0-9]+).([0-9]+)$`)
+	spacesRegex   = regexp.MustCompile(`\s`)
 )
 
 const (
@@ -37,10 +35,8 @@ func init() {
 	actionsRoot.AddCommand(actionsNew)
 	actionsRoot.AddCommand(actionsValidate)
 	actionsRoot.AddCommand(actionsDeploy)
-	actionsRoot.AddCommand(actionsPublish)
 
 	actionsDeploy.Flags().BoolVar(&pushOnly, "push-only", false, "Only push the action code;  do not create the action version")
-	actionsDeploy.Flags().BoolVar(&deployWithoutPublish, "no-publish", false, "Do not publish this action after deploying.  This action will only be useable by test workflows.")
 	actionsList.Flags().BoolVar(&includePublic, "public", false, "Include publicly available actions")
 }
 
@@ -158,15 +154,10 @@ var actionsDeploy = &cobra.Command{
 			Version:  version,
 		})
 		if err != nil {
-			log.From(ctx).Fatal().Msgf("Error deploying: %s.  To push your image to an existing action, run with --push-only.", err)
+			log.From(ctx).Fatal().Msgf("Error deploying: %s.", err)
 		}
 
-		if !deployWithoutPublish {
-			actionsPublish.Run(cmd, []string{
-				version.DSN,
-				fmt.Sprintf("v%d.%d", version.Version.Major, version.Version.Minor),
-			})
-		}
+		return
 	},
 }
 
@@ -195,47 +186,5 @@ var actionsNew = &cobra.Command{
 		fmt.Println("Edit this file with your configuration and deploy using `inngestctl actions deploy`.")
 
 		return nil
-	},
-}
-
-var actionsPublish = &cobra.Command{
-	Use:   "publish [dsn] [version, eg. v1.12]",
-	Short: "Pubishes a specific action version for use within workflows",
-	Args: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 2 {
-			return errors.New("An action DSN and version must be spplied, eg: $ inngestctl actions publish my-account/hello world v1.1")
-		}
-		// Check action version
-		match := versionRegex.MatchString(args[1])
-		if !match {
-			return errors.New("Verion must be specified in the format of ${major}.${minor}, eg. v1.23 or 2.54")
-		}
-
-		return nil
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		ctx := cmd.Context()
-		state := state.RequireState(ctx)
-
-		v := versionRegex.FindStringSubmatch(args[1])
-		major, err := strconv.Atoi(v[1])
-		if err != nil {
-			log.From(ctx).Fatal().Msg(err.Error())
-		}
-		minor, err := strconv.Atoi(v[2])
-		if err != nil {
-			log.From(ctx).Fatal().Msg(err.Error())
-		}
-
-		log.From(ctx).Info().Msg("Publishing action")
-		_, err = state.Client.UpdateActionVersion(ctx, client.ActionVersionQualifier{
-			DSN:          args[0],
-			VersionMajor: major,
-			VersionMinor: minor,
-		}, true)
-		if err != nil {
-			log.From(ctx).Fatal().Msg(err.Error())
-		}
-		log.From(ctx).Info().Msg("Action published")
 	},
 }

--- a/cmd/commands/internal/actions/parse.go
+++ b/cmd/commands/internal/actions/parse.go
@@ -1,0 +1,40 @@
+package actions
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/inngest/inngestctl/inngest"
+)
+
+// Parse parses an action.  This differs from inngest.ParseAction as we automatically
+// prefix the action DSN with the given account identifier if not present.
+func Parse(accountPrefix, input string) (version *inngest.ActionVersion, formatted string, err error) {
+	version, err = inngest.ParseAction(input)
+
+	if err != nil || strings.Contains(version.DSN, "/") {
+		return version, input, err
+	}
+
+	// We have an action, but there was an error parsing.  There's
+	// one situation in which we allow the local CLI to parse invalid
+	// actions:  creating a .cue config with no account prefix in the
+	// action DSN.
+	//
+	// We don't want you to have to put your account prefix in the DSN:
+	// "http" instead of "funky-albatross-81236/http".  This makes it easy
+	// for people to clone & push actions without having to change the DSN.
+	//
+	// Here, check to see if the action DSN has a slash in it.  If not,
+	// add our account prefix and re-serialize the action cue.
+	//
+	// XXX: this is a code smell.  in v2, reformat the account cue config
+	//      to make this nicer (remove account identifiers / separate, etc).
+	if !strings.Contains(version.DSN, "/") {
+		version.DSN = fmt.Sprintf("%s/%s", accountPrefix, version.DSN)
+	}
+
+	// Re-format the cue config and return the newly formatted data.
+	formatted, err = inngest.FormatAction(*version)
+	return version, formatted, err
+}

--- a/inngest/action.go
+++ b/inngest/action.go
@@ -14,7 +14,7 @@ import (
 func ParseAction(input string) (*ActionVersion, error) {
 	val, err := cuedefs.ParseAction(input)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing action definition: %w", err)
+		return nil, err
 	}
 	a := &ActionVersion{}
 	if err := val.Decode(&a); err != nil {

--- a/inngest/internal/cuedefs/cuedefs.go
+++ b/inngest/internal/cuedefs/cuedefs.go
@@ -117,7 +117,7 @@ func parseDef(input, lookup, suffix string) (*cue.Value, error) {
 	if err := inst.Err(); err != nil {
 		buf := &bytes.Buffer{}
 		cueerrors.Print(buf, err, nil)
-		return nil, fmt.Errorf("config is invalid: %s", buf.String())
+		return nil, fmt.Errorf("error parsing config: %s", buf.String())
 	}
 
 	// Find the variable defined as "workflow":  this is a constant used to reference

--- a/inngest/internal/cuedefs/pkg/actions/actions.cue
+++ b/inngest/internal/cuedefs/pkg/actions/actions.cue
@@ -10,7 +10,11 @@ import (
 
 #Action: {
 	name: string
-	dsn:  =~"^[a-z0-9-.]+/[a-z0-9-]+$"
+
+	// Locally, we allow action DSNs to exist without account prefixes so that you can
+	// push and clone actions easily.  We automatically add the signed in user's account
+	// prefix to this DSN before pushing.
+	dsn: =~"^([a-z0-9-.]+/)?[a-z0-9-]+$"
 
 	version: {
 		major: >0 | *1


### PR DESCRIPTION
This PR makes the process of deploying actions a little bit easier.  We've made the following changes:

**1. Auto-deploy and publish**

Running `inngestctl actions deploy ./action.cue` now pushes the image, creates the action, and publishes the action in one step.  Previously, "deploy" would push the action and you'd have to separately publish the action for it to be usable.  This was a bit confusing.

**2. Allow publishing of actions with no account identifier**.

When defining actions, you previously had to write your account identifier in the local cue config:

```
action: actions.#Action & {
  dsn: "my-account-id/hello-world"
}
```

This is error prone when testing & when forking actions.  Now, our CLI automatically adds your account prefix on deploy if it's not specified.