### PR TITLE
Do not require login for action validation

### DIFF
--- a/cmd/commands/actions.go
+++ b/cmd/commands/actions.go
@@ -105,7 +105,7 @@ var actionsValidate = &cobra.Command{
 		ctx := cmd.Context()
 
 		prefix := ""
-		if state := state.RequireState(ctx); state != nil {
+		if state, _ := state.GetState(ctx); state != nil {
 			prefix = state.Account.Identifier.DSNPrefix
 		}
 


### PR DESCRIPTION
### Purpose
So users can validate without login and users (and us) can use this in CI easily. 