### PR TITLE
Prevent non amd64 images during push

### DIFF
--- a/inngest/deploy.go
+++ b/inngest/deploy.go
@@ -91,15 +91,15 @@ func prepareAndPushImage(ctx context.Context, a deployImageOptions) (err error) 
 	}
 
 	if a.image == "" {
-		return fmt.Errorf("no image specified")
+		return errors.New("no image specified")
 	}
 
 	resp, _, err := dkr.ImageInspectWithRaw(ctx, a.image)
 	if err != nil {
-		return fmt.Errorf("could not locate image")
+		return errors.New("could not locate image")
 	}
-	if resp.Architecture != "amd64" {
-		return fmt.Errorf("image architecture is not amd64, please rebuild")
+	if resp.Architecture != "amd64" || resp.Os != "linux" {
+		return errors.New("image architecture is not linux/amd64, please rebuild")
 	}
 
 	return pushImage(ctx, a, dkr)

--- a/inngest/deploy.go
+++ b/inngest/deploy.go
@@ -96,7 +96,7 @@ func prepareAndPushImage(ctx context.Context, a deployImageOptions) (err error) 
 
 	resp, _, err := dkr.ImageInspectWithRaw(ctx, a.image)
 	if err != nil {
-		return errors.New("could not locate image")
+		return err
 	}
 	if resp.Architecture != "amd64" || resp.Os != "linux" {
 		return errors.New("image architecture is not linux/amd64, please rebuild")

--- a/inngest/deploy.go
+++ b/inngest/deploy.go
@@ -94,6 +94,14 @@ func prepareAndPushImage(ctx context.Context, a deployImageOptions) (err error) 
 		return fmt.Errorf("no image specified")
 	}
 
+	resp, _, err := dkr.ImageInspectWithRaw(ctx, a.image)
+	if err != nil {
+		return fmt.Errorf("could not locate image")
+	}
+	if resp.Architecture != "amd64" {
+		return fmt.Errorf("image architecture is not amd64, please rebuild")
+	}
+
 	return pushImage(ctx, a, dkr)
 }
 


### PR DESCRIPTION
# Purpose
Prior to the upcoming cli work, it's good to prevent pushing non amd64 images that we cannot run.