### PR TITLE
Prefer using domains on action deploy

### DIFF
--- a/cmd/commands/actions.go
+++ b/cmd/commands/actions.go
@@ -160,7 +160,12 @@ var actionsDeploy = &cobra.Command{
 			log.From(ctx).Fatal().Msgf("Error reading configuration: %s", err)
 		}
 
-		version, cueConfig, err := actions.Parse(state.Account.Identifier.DSNPrefix, string(byt))
+		prefix := state.Account.Identifier.DSNPrefix
+		if state.Account.Identifier.Domain != nil {
+			prefix = *state.Account.Identifier.Domain
+		}
+
+		version, cueConfig, err := actions.Parse(prefix, string(byt))
 		if err != nil {
 			log.From(ctx).Fatal().Msgf("Error reading configuration: %s", err)
 		}

--- a/inngest/deploy.go
+++ b/inngest/deploy.go
@@ -13,6 +13,7 @@ import (
 	docker "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/inngest/inngestctl/inngest/client"
+	"github.com/inngest/inngestctl/inngest/log"
 )
 
 const (
@@ -33,6 +34,8 @@ type DeployActionOptions struct {
 // DeployAction pushes the action to Inngest, making it available for use within
 // all workflows.
 func DeployAction(ctx context.Context, opts DeployActionOptions) (*ActionVersion, error) {
+	log.From(ctx).Info().Msgf("Deploying action %s\n", opts.Version.DSN)
+
 	if opts.Version == nil {
 		version, err := ParseAction(opts.Config)
 		if err != nil {


### PR DESCRIPTION
Use the domain instead of the DSN prefix and display the full generated DSN to the user.

We added this for validation in #20 