### PR TITLE
Remove duplicate field Scopes

### DIFF
--- a/inngest/action.go
+++ b/inngest/action.go
@@ -49,8 +49,6 @@ type ActionVersion struct {
 	// amount of time.
 	WorkflowMetadata MetadataMap `json:"workflowMetadata"`
 
-	Scopes []string `json:"scopes"`
-
 	// Response defines the response type for this action.  This allows us to show UI-specific
 	// information around the "stack" or "baggage" that is built up around your workflow as
 	// actions run.


### PR DESCRIPTION
Both #26 and #29 had added Scopes, but I had failed to rebase #29 from `main` shortly after #26 was merged. This removes the duplicate.