### PR TITLE
Fall back to unauthed events on err, ignore "already up to date" scaffolds

### DIFF
--- a/pkg/cli/initialize_fn.go
+++ b/pkg/cli/initialize_fn.go
@@ -498,7 +498,8 @@ func fetchEvents() ([]client.Event, error) {
 		WorkspaceID: workspaceID,
 	})
 	if err != nil {
-		return nil, err
+		// Attempt to fetch unauthed events.
+		return c.AllEvents(ctx, nil)
 	}
 	return evts, nil
 }

--- a/pkg/scaffold/scaffold.go
+++ b/pkg/scaffold/scaffold.go
@@ -107,7 +107,13 @@ func update(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return w.Pull(&git.PullOptions{RemoteName: "origin"})
+
+	err = w.Pull(&git.PullOptions{RemoteName: "origin"})
+	if err == git.NoErrAlreadyUpToDate {
+		return nil
+	}
+
+	return err
 }
 
 // clone clones the scaffold directory into


### PR DESCRIPTION
This improves the error messages shown within the event list and when loading scaffolds.