### PR TITLE
Show new event in event list to make autocomplete easier

### DIFF
--- a/pkg/cli/initialize_fn.go
+++ b/pkg/cli/initialize_fn.go
@@ -174,7 +174,7 @@ func (f *initModel) Init() tea.Cmd {
 	}()
 
 	// Remove the first N lines of the CLI height, which account for the header etc.
-	f.browser, _ = NewEventBrowser(f.width, f.height-eventBrowserOffset, f.events)
+	f.browser, _ = NewEventBrowser(f.width, f.height-eventBrowserOffset, f.events, true)
 
 	go func() {
 		f.scaffoldCacheError = scaffold.UpdateCache(context.Background())
@@ -274,6 +274,10 @@ func (f *initModel) updateEvent(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if f.event == "" {
 				// There's no name, so don't do anything.
 				return f, nil
+			}
+
+			if sel := f.browser.Selected(); sel != nil {
+				f.event = sel.Name
 			}
 
 			// If we've attempted to update the scaffolds but have zero languages available,


### PR DESCRIPTION
This renders the new event you're typing at the top of the event browser
list, making it easy to see which event you have selected and what will
be used on enter keypress.


https://user-images.githubusercontent.com/306177/157762729-cc353538-11d5-4fc3-b86e-dfbdac6764bf.mov

