### PR TITLE
Render empty type with no event schemas in typescript.

### DIFF
--- a/pkg/scaffold/template.go
+++ b/pkg/scaffold/template.go
@@ -84,7 +84,7 @@ func (t Template) Render(f function.Function) error {
 				}
 
 				if len(names) == 0 {
-					return ""
+					return "export type EventTriggers = {};"
 				}
 
 				// Write an enum which joins all event triggers.


### PR DESCRIPTION
This fixes an invalid TS file, by rendering:

```js
export type EventTriggers = {};

export type Args = {
  event: EventTriggers;
  actions: {
    [clientID: string]: any
  };
};
```

Instead of the broken:

```js

export type Args = {
  event: EventTriggers; // undefined.
  actions: {
    [clientID: string]: any
  };
};
```