### PR TITLE
Render event types into ./events/ within scaffolded directories.

### DIFF
--- a/pkg/cli/initialize_fn.go
+++ b/pkg/cli/initialize_fn.go
@@ -271,13 +271,13 @@ func (f *initModel) updateEvent(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if key, ok := msg.(tea.KeyMsg); ok {
 		switch key.Type {
 		case tea.KeyEnter:
+			if sel := f.browser.Selected(); sel != nil {
+				f.event = sel.Name
+			}
+
 			if f.event == "" {
 				// There's no name, so don't do anything.
 				return f, nil
-			}
-
-			if sel := f.browser.Selected(); sel != nil {
-				f.event = sel.Name
 			}
 
 			// If we've attempted to update the scaffolds but have zero languages available,

--- a/pkg/function/config.go
+++ b/pkg/function/config.go
@@ -76,6 +76,8 @@ func Unmarshal(input []byte) (*Function, error) {
 	return fn, nil
 }
 
+// MarshalJSON marshals a function to pretty JSON.  It's a plain wrapper
+// around json.MarshalIndent with defaults.
 func MarshalJSON(f Function) ([]byte, error) {
 	return json.MarshalIndent(f, "", "  ")
 }


### PR DESCRIPTION
This PR ensures that we create a folder for all event definitions, vs
bundling them in a string within `inngest.json`.  It makes the
definitions easier to read.  In the future, it also allows us to offer
event mutations directly from the function deploys.