### PR TITLE
Nits and fixes from usage

### DIFF
--- a/cmd/commands/deploy.go
+++ b/cmd/commands/deploy.go
@@ -98,8 +98,9 @@ func deployAction(ctx context.Context, a inngest.ActionVersion) error {
 	ui, err := cli.NewBuilder(ctx, cli.BuilderUIOpts{
 		QuitOnComplete: true,
 		BuildOpts: docker.BuildOpts{
-			Path: ".",
-			Tag:  tag,
+			Path:     ".",
+			Tag:      tag,
+			Platform: "linux/amd64",
 		},
 	})
 	if err != nil {

--- a/cmd/commands/login.go
+++ b/cmd/commands/login.go
@@ -2,11 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"os"
 	"syscall"
 
 	"github.com/inngest/inngestctl/inngest/client"
 	"github.com/inngest/inngestctl/inngest/log"
 	"github.com/inngest/inngestctl/inngest/state"
+	"github.com/inngest/inngestctl/pkg/cli"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"golang.org/x/term"
@@ -42,7 +44,8 @@ func NewCmdLogin() *cobra.Command {
 			fmt.Println("Logging in...")
 			jwt, err := client.New(client.WithAPI(viper.GetString("api"))).Login(ctx, username, password)
 			if err != nil {
-				log.From(ctx).Fatal().Msgf("unable to log in: %s", err.Error())
+				fmt.Println(cli.RenderError(fmt.Sprintf("unable to log in: %s", err.Error())))
+				os.Exit(1)
 			}
 
 			// Fetch the account.
@@ -52,7 +55,12 @@ func NewCmdLogin() *cobra.Command {
 			)
 			account, err := client.Account(ctx)
 			if err != nil {
-				log.From(ctx).Fatal().Msgf("unable to fetch account: %s", err.Error())
+				fmt.Println(cli.RenderError(fmt.Sprintf("unable to log in: %s", err.Error())))
+				os.Exit(1)
+			}
+			if account == nil {
+				fmt.Println(cli.RenderError(fmt.Sprintf("unable to log in: %s", err.Error())))
+				os.Exit(1)
 			}
 
 			// Find their workspaces, and select the default workspace.

--- a/cmd/commands/run.go
+++ b/cmd/commands/run.go
@@ -41,6 +41,7 @@ func doRun(cmd *cobra.Command, args []string) {
 
 	err = runFunction(cmd.Context(), *fn)
 	if err != nil {
+		fmt.Println("\n" + cli.RenderError(err.Error()))
 		os.Exit(1)
 	}
 }

--- a/inngest/client/client.go
+++ b/inngest/client/client.go
@@ -51,8 +51,7 @@ type ClientOpt func(Client) Client
 func New(opts ...ClientOpt) Client {
 	c := &httpClient{
 		Client: http.DefaultClient,
-		//api:    "https://api.inngest.com",
-		api:    "http://127.0.0.1:8090",
+		api:    "https://api.inngest.com",
 		ingest: "https://inn.gs",
 	}
 

--- a/pkg/docker/executor.go
+++ b/pkg/docker/executor.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -120,7 +121,6 @@ func (d *DockerExecutor) start(ctx context.Context, action inngest.ActionVersion
 }
 
 func (d *DockerExecutor) startOpts(ctx context.Context, action inngest.ActionVersion, state map[string]interface{}) (docker.CreateContainerOptions, error) {
-
 	marshalled, err := json.Marshal(map[string]interface{}{
 		"args_version": 1,
 		"metadata": map[string]interface{}{
@@ -149,6 +149,8 @@ func (d *DockerExecutor) startOpts(ctx context.Context, action inngest.ActionVer
 		Config: &docker.Config{
 			Image: action.DSN,
 			Cmd:   []string{string(marshalled)},
+			// Add all env vars from the local machine
+			Env: os.Environ(),
 		},
 	}, nil
 }


### PR DESCRIPTION
This commit adds fixes for:

- Production builds
- Checking the presence of x86 cross-compilation, with a warning on how to fix
- Env vars being passed to `inngestctl run`